### PR TITLE
fix: Redirect oomusou.io to old-oomusou.goodjack.tw

### DIFF
--- a/document/EFCore/ReadMe.md
+++ b/document/EFCore/ReadMe.md
@@ -118,6 +118,6 @@ Scaffold-DbContext "Server=localhost;Database=MARS;Trusted_Connection=True;" Mic
 
 ## 參考
 
-- [如何在 Entity Framework Core 使用 Migration ? (PostgreSQL)](https://oomusou.io/efcore/migration/)
+- [如何在 Entity Framework Core 使用 Migration ? (PostgreSQL)](https://old-oomusou.goodjack.tw/efcore/migration/)
 
 (fin)


### PR DESCRIPTION
舊的 oomusou.io 文章已經轉移至 old-oomusou.goodjack.tw